### PR TITLE
URL Cleanup

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -7,7 +7,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/company/Company.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/company/Company.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/company/CompanyOrderBookListener.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/company/CompanyOrderBookListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/DigestUtils.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/DigestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/PortfolioManagementUserListener.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/PortfolioManagementUserListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/User.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/command/user/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyEventHandler.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyViewRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyViewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookEventHandler.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookViewRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookViewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/trades/OrderBookView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/trades/OrderBookView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/trades/OrderView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/trades/OrderView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TradeExecutedQueryRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TradeExecutedQueryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TradeExecutedView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TradeExecutedView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TransactionView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/orders/transaction/TransactionView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/ItemEntry.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/ItemEntry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioEventHandler.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioViewRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioViewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionEventHandler.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionViewRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionViewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserAccount.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserAccount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserEventHandler.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserView.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserViewRepository.java
+++ b/trader-app/src/main/java/io/pivotal/refarch/cqrs/trader/app/query/users/UserViewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/command/user/PortfolioManagementUserListenerTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/command/user/PortfolioManagementUserListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/command/user/UserTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/command/user/UserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyRepositoryIntegrationTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/company/CompanyRepositoryIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookEventHandlerIntegrationTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/orderbook/OrderBookEventHandlerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioEventHandlerTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioEventHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioViewTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/portfolio/PortfolioViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionEventHandlerTest.java
+++ b/trader-app/src/test/java/io/pivotal/refarch/cqrs/trader/app/query/transaction/TransactionEventHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/BuyTradeManagerSaga.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/BuyTradeManagerSaga.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/Portfolio.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/Portfolio.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/SellTradeManagerSaga.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/SellTradeManagerSaga.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/Transaction.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/Transaction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/Order.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/OrderBook.java
+++ b/trading-engine/src/main/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/OrderBook.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/BuyTradeManagerSagaTest.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/BuyTradeManagerSagaTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/PortfolioTest.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/PortfolioTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/SellTradeManagerSagaTest.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/SellTradeManagerSagaTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/TransactionCommandHandlingTest.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/TransactionCommandHandlingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/matchers/CreateBuyOrderCommandMatcher.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/matchers/CreateBuyOrderCommandMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/matchers/CreateSellOrderCommandMatcher.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/order/matchers/CreateSellOrderCommandMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/OrderBookTest.java
+++ b/trading-engine/src/test/java/io/pivotal/refarch/cqrs/trader/tradingengine/trade/OrderBookTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 46 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).