### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CQRS and Event Sourcing on Cloud Foundry
 
-This project demonstrates the the use of CQRS and Event Sourcing with Cloud Foundry. It contains two [Spring Boot](http://projects.spring.io/spring-boot/) microservices, both built using components provided by the [Axon Framework](http://www.axonframework.org/). You can read the [blog post that accompanies this project over on Wordpress](https://benwilcock.wordpress.com/2017/07/11/cqrs-and-event-sourcing-microservices-on-cloudfoundry/).
+This project demonstrates the the use of CQRS and Event Sourcing with Cloud Foundry. It contains two [Spring Boot](https://projects.spring.io/spring-boot/) microservices, both built using components provided by the [Axon Framework](https://axoniq.io). You can read the [blog post that accompanies this project over on Wordpress](https://benwilcock.wordpress.com/2017/07/11/cqrs-and-event-sourcing-microservices-on-cloudfoundry/).
 
 > **This CQRS application is designed to run exclusively on Cloud Foundry.**
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.axonframework.org/ (301) with 1 occurrences migrated to:  
  https://axoniq.io ([https](https://www.axonframework.org/) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://projects.spring.io/spring-boot/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8000 with 1 occurrences
* http://localhost:8080/command/api with 1 occurrences
* http://localhost:8080/company/ with 1 occurrences
* http://localhost:8080/orderbook/a869e39d-4e97-4d1e-a662-2690f992c28d with 2 occurrences
* http://localhost:8080/status with 1 occurrences
* http://localhost:8761/ with 1 occurrences